### PR TITLE
removed check-then-lock race condition

### DIFF
--- a/fballiano-magento-cache-regeneration-lock.patch
+++ b/fballiano-magento-cache-regeneration-lock.patch
@@ -11,7 +11,7 @@ diff --git a/app/code/local/Mage/Core/Model/App.php b/app/code/local/Mage/Core/M
 index 56f5765..552935d 100644
 --- a/app/code/local/Mage/Core/Model/App.php
 +++ b/app/code/local/Mage/Core/Model/App.php
-@@ -422,6 +422,32 @@ class Mage_Core_Model_App
+@@ -422,6 +422,43 @@ class Mage_Core_Model_App
      protected function _initModules()
      {
          if (!$this->_config->loadModulesCache()) {
@@ -26,25 +26,36 @@ index 56f5765..552935d 100644
 +                $lock = new Mage_Index_Model_Resource_Helper_Mysql4("index");
 +            }
 +            $lock->setWriteAdapter($connection);
-+            if ($lock->isLocked("fballiano_cache_regeneration")) {
-+                $loopcounter = 0;
-+                do {
-+                    if ($loopcounter++ > 20) {
-+                        header("504 Gateway Timeout", true, 504);
-+                        die();
++            $loopcounter = 0;
++            while (true) {
++                //try to get the lock. failure means someone else holds the lock
++                if ($lock->setLock("fballiano_cache_regeneration")) {
++                    if ($loopcounter == 0) {
++                        //we got the lock on first try. proceed to building the cache content
++                        break;
 +                    }
-+                    sleep(3);
-+                } while ($lock->isLocked("fballiano_cache_regeneration"));
-+                $this->_config->loadModulesCache();
-+                return $this;
++
++                    //we didnt get the lock on first try, so someone else was building the cache content
++                    //lets try to use that
++                    if ($this->_config->loadModulesCache()) {
++                        $lock->releaseLock("fballiano_cache_regeneration");
++                        return $this;
++                    }
++
++                    //cache was empty or corrupt. proceed to building the cache content
++                    break;
++                }
++                if ($loopcounter++ > 20) {
++                    header("504 Gateway Timeout", true, 504);
++                    die();
++                }
 +            }
-+            $lock->setLock("fballiano_cache_regeneration");
 +            //FBALLIANO CACHE GENERATION LOCK END
 +
              $this->_config->loadModules();
              if ($this->_config->isLocalConfigLoaded() && !$this->_shouldSkipProcessModulesUpdates()) {
                  Varien_Profiler::start('mage::app::init::apply_db_schema_updates');
-@@ -430,6 +456,10 @@ class Mage_Core_Model_App
+@@ -430,6 +467,10 @@ class Mage_Core_Model_App
              }
              $this->_config->loadDb();
              $this->_config->saveCache();

--- a/fballiano-magento-cache-regeneration-lock.patch
+++ b/fballiano-magento-cache-regeneration-lock.patch
@@ -11,7 +11,7 @@ diff --git a/app/code/local/Mage/Core/Model/App.php b/app/code/local/Mage/Core/M
 index 56f5765..552935d 100644
 --- a/app/code/local/Mage/Core/Model/App.php
 +++ b/app/code/local/Mage/Core/Model/App.php
-@@ -422,6 +422,43 @@ class Mage_Core_Model_App
+@@ -422,6 +422,38 @@ class Mage_Core_Model_App
      protected function _initModules()
      {
          if (!$this->_config->loadModulesCache()) {
@@ -30,13 +30,8 @@ index 56f5765..552935d 100644
 +            while (true) {
 +                //try to get the lock. failure means someone else holds the lock
 +                if ($lock->setLock("fballiano_cache_regeneration")) {
-+                    if ($loopcounter == 0) {
-+                        //we got the lock on first try. proceed to building the cache content
-+                        break;
-+                    }
-+
-+                    //we didnt get the lock on first try, so someone else was building the cache content
-+                    //lets try to use that
++                    //perhaps someone else was building cache content while we waited for the lock
++                    //lets see if we can load anything
 +                    if ($this->_config->loadModulesCache()) {
 +                        $lock->releaseLock("fballiano_cache_regeneration");
 +                        return $this;
@@ -55,7 +50,7 @@ index 56f5765..552935d 100644
              $this->_config->loadModules();
              if ($this->_config->isLocalConfigLoaded() && !$this->_shouldSkipProcessModulesUpdates()) {
                  Varien_Profiler::start('mage::app::init::apply_db_schema_updates');
-@@ -430,6 +467,10 @@ class Mage_Core_Model_App
+@@ -430,6 +462,10 @@ class Mage_Core_Model_App
              }
              $this->_config->loadDb();
              $this->_config->saveCache();


### PR DESCRIPTION
This commit removes the race condition, which comes from first checking whether a lock is locked, and if not, then only setting the the lock (aka "check-then-lock" approach).

The problem with the "check-then-lock" approach is, that between checking `isLocked` and the subsequent `setLock` statement, some other process could in theory (e.g. under high-concurrency) manage to set the lock. The original patch also called `setLock` unconditionally, so if it failed (which it could, due to it's non-blocking implementation), we would potentially continue without actually having the lock.

It is almost always best to ignore "isLocked" in locking algorithms, and simply try to set the lock directly. In case of failure to set the lock, it means that someone else already has the lock (i.e. `isLocked == true` by implication). Of course we should always have a back-off strategy (as the original patch does), so if locking fails too often, or for any other technical reason, we will still back off safely.

This commit has 3 major changes:
1) Instead of "check-then-lock", it does "try-lock"
2) The return value of `$this->_config->loadModulesCache()` is now honoured, so a (quite-unlikely) failure of that call would also be handled correctly.
3) The sleep statement was removed, because we already wait for up to 5 seconds per loop-iteration due to `setLock()`'s internal timeout for waiting for the lock.
